### PR TITLE
Add --add-opens JVM argument to Maven Compiler Plugin for JDK module access

### DIFF
--- a/dataexport-core/pom.xml
+++ b/dataexport-core/pom.xml
@@ -66,6 +66,10 @@
 				<version>3.8.0</version>
 				<configuration>
 					<release>11</release>
+					<compilerArgs>
+						<arg>--add-opens</arg>
+						<arg>jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+					</compilerArgs>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
Add --add-opens JVM argument to Maven Compiler Plugin for JDK module access

- Configured Maven Compiler Plugin to add '--add-opens jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED' JVM argument
- This resolves access issues with internal JDK classes when using JDK 9 or higher
