### PR TITLE
Upload artifact using S3 Maven Repo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,36 +12,22 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 11
-      - name: Cache local Maven repository
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          distribution: 'temurin'
+          cache: 'maven'
+          server-id: uwdigi-maven
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_TOKEN
 
       - name: Build and Test
         run: mvn --batch-mode --update-snapshots clean package -DskipTests
 
-      - name: Set settings.xml
-        uses: s4u/maven-settings-action@v2.6.0
-        with:
-          servers: |
-            [{
-              "id": "uwdigi-repo-central",
-              "username": "${{ secrets.MAVEN_REPO_USERNAME }}",
-              "password": "${{ secrets.MAVEN_REPO_PASSWORD }}"
-            },
-            {
-              "id": "uwdigi-repo-snapshots",
-              "username": "${{ secrets.MAVEN_REPO_USERNAME }}",
-              "password": "${{ secrets.MAVEN_REPO_PASSWORD }}"
-            }]
-        if: ${{ github.ref == 'refs/heads/master' && github.repository_owner == 'I-TECH-UW' }}
-
       - name: Deploy
-        run: mvn --batch-mode clean deploy -DskipTests
         if: ${{ github.ref == 'refs/heads/master' && github.repository_owner == 'I-TECH-UW' }}
+        run: mvn --batch-mode clean deploy -DskipTests
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
+        

--- a/pom.xml
+++ b/pom.xml
@@ -12,24 +12,27 @@
 		<java.version>11</java.version>
 		<maven.compiler.release>11</maven.compiler.release>
 	</properties>
-	 
+
 	<repositories>
 		<repository>
-			<id>uwdigi-repo-central</id>
-			<name>DIGI Public Repository</name>
-			<url>https://packages.uwdigi.org/artifactory/public</url>
+				<id>uwdigi-maven</id>
+				<name>DIGI Public Repository</name>
+				<url>s3://openelis-maven-repo/snapshots</url>
+				<snapshots>
+					<enabled>true</enabled>
+				</snapshots>
 		</repository>
 	</repositories>
 	<distributionManagement>
 		<repository>
-			<id>uwdigi-repo-central</id>
-			<name>libs-release</name>
-			<url>https://packages.uwdigi.org/artifactory/libs-release</url>
+			<id>uwdigi-maven</id>
+			<name>DIGI Public Repository</name>
+			<url>s3://openelis-maven-repo/releases</url>
 		</repository>
 		<snapshotRepository>
-			<id>uwdigi-repo-snapshots</id>
-			<name>libs-snapshot</name>
-			<url>https://packages.uwdigi.org/artifactory/libs-snapshot</url>
+			<id>uwdigi-maven</id>
+			<name>DIGI Public Repository</name>
+			<url>s3://openelis-maven-repo/snapshots</url>
 		</snapshotRepository>
 	</distributionManagement>
 
@@ -59,6 +62,13 @@
 	</dependencies>
 
 	<build>
+		<extensions>
+			<extension>
+				<groupId>org.kuali.maven.wagons</groupId>
+				<artifactId>maven-s3-wagon</artifactId>
+				<version>1.2.1</version>
+			</extension>
+		</extensions>
 		<plugins>
 			<plugin>
 				<groupId>com.spotify</groupId>


### PR DESCRIPTION
This implements support for deploying the `dataexport` module to an S3 bucket that serves as a Maven repo. This repo should be globally readable, but writing can only be done via CI.

I haven't done corresponding changes for OpenELIS because I don't really understand how to integrate this into that flow, but it should be a matter of copying the relevant bits from this PR.